### PR TITLE
Fix wrong imports and functions used on test classes. (to pass travis checks)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,20 +58,20 @@ android {
 
 dependencies {
     implementation 'org.apache.james:apache-mime4j-core:0.7.2'
-    implementation 'org.apache.httpcomponents:httpclient:4.2.1'
-    implementation 'org.apache.httpcomponents:httpcore:4.2.1'
-    implementation 'org.apache.httpcomponents:httpmime:4.2.1'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.10'
+    implementation 'org.apache.httpcomponents:httpmime:4.5.6'
     implementation 'org.osmdroid:osmdroid-android:5.6.5'
     implementation 'oauth.signpost:signpost-commonshttp4:1.2.1.2'
     implementation 'org.slf4j:slf4j-android:1.7.25'
-    implementation "com.android.support:support-compat:27.1.1"
+    implementation "com.android.support:support-compat:28.0.0"
 
     // Required for local unit tests (JUnit 4 framework)
     testImplementation 'junit:junit:4.12'
 
     // Required for instrumented tests
-    androidTestImplementation "com.android.support.test:runner:1.0.0"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.0"
+    androidTestImplementation "com.android.support.test:runner:1.0.2"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
+    androidTestImplementation "com.android.support.test:rules:1.0.2"
 
 }
 

--- a/app/src/androidTest/java/net/osmtracker/test/activity/OSMUploadTest.java
+++ b/app/src/androidTest/java/net/osmtracker/test/activity/OSMUploadTest.java
@@ -1,18 +1,13 @@
 package net.osmtracker.test.activity;
 
+import android.support.test.rule.ActivityTestRule;
+
 import net.osmtracker.activity.OpenStreetMapUpload;
 
-import android.test.ActivityInstrumentationTestCase2;
-
-public class OSMUploadTest extends ActivityInstrumentationTestCase2<OpenStreetMapUpload> {
+public class OSMUploadTest extends ActivityTestRule<OpenStreetMapUpload> {
 
 	public OSMUploadTest() {
-		super("net.osmtracker", OpenStreetMapUpload.class);
-	}
-	
-	@Override
-	protected void setUp() throws Exception {
-		// MockData.mockBigTrack(getInstrumentation().getContext(), 2000, 2000);
+		super(OpenStreetMapUpload.class);
 	}
 	
 	public void test() {

--- a/app/src/androidTest/java/net/osmtracker/test/activity/TrackDetailTest.java
+++ b/app/src/androidTest/java/net/osmtracker/test/activity/TrackDetailTest.java
@@ -1,5 +1,16 @@
 package net.osmtracker.test.activity;
 
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.Intent;
+import android.database.Cursor;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.ActivityTestRule;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Spinner;
+
 import junit.framework.Assert;
 
 import net.osmtracker.activity.TrackDetail;
@@ -7,37 +18,26 @@ import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.db.TrackContentProvider.Schema;
 import net.osmtracker.test.util.MockData;
 
-import android.content.ContentResolver;
-import android.content.ContentUris;
-import android.content.Intent;
-import android.database.Cursor;
-import android.test.ActivityInstrumentationTestCase2;
-import android.test.UiThreadTest;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.Spinner;
-
-public class TrackDetailTest extends ActivityInstrumentationTestCase2<TrackDetail> {
+public class TrackDetailTest extends ActivityTestRule<TrackDetail> {
 
 	private long trackId;
 	
 	public TrackDetailTest() {
-		super("net.osmtracker", TrackDetail.class);
+		super(TrackDetail.class);
 	}
-	
-	@Override
+
 	protected void setUp() throws Exception {
-		trackId = MockData.mockTrack(getInstrumentation().getContext());
+		trackId = MockData.mockTrack(InstrumentationRegistry.getInstrumentation().getContext());
 		
 		Intent i = new Intent();
 		i.putExtra(Schema.COL_TRACK_ID, trackId);
-		setActivityIntent(i);
+		launchActivity(i);
 	}
 	
 	@UiThreadTest
 	public void testSave() {
 		
-		ContentResolver cr = getInstrumentation().getContext().getContentResolver();
+		ContentResolver cr = InstrumentationRegistry.getInstrumentation().getContext().getContentResolver();
 		Cursor cursor = cr.query(
 				ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId),
 				null, null, null, null);

--- a/app/src/androidTest/java/net/osmtracker/test/gpx/ExportTrackTaskTest.java
+++ b/app/src/androidTest/java/net/osmtracker/test/gpx/ExportTrackTaskTest.java
@@ -9,8 +9,9 @@ import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.ActivityInstrumentationTestCase2;
 
 import junit.framework.Assert;
 
@@ -32,10 +33,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import android.support.test.rule.GrantPermissionRule;
-
 @RunWith(AndroidJUnit4.class)
-public class ExportTrackTaskTest extends ActivityInstrumentationTestCase2<TrackManager> {
+public class ExportTrackTaskTest extends ActivityTestRule<TrackManager> {
 
 	private long trackId;
 	private File trackFile;
@@ -47,12 +46,12 @@ public class ExportTrackTaskTest extends ActivityInstrumentationTestCase2<TrackM
 	public GrantPermissionRule mRuntimePermissionRuleRead = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
 
 	public ExportTrackTaskTest() {
-		super("net.osmtracker", TrackManager.class);
+		super(TrackManager.class);
 	}
 
 	@Before
 	public void setUp() throws Exception {
-		injectInstrumentation(InstrumentationRegistry.getInstrumentation());
+		InstrumentationRegistry.registerInstance(InstrumentationRegistry.getInstrumentation(), null);
 		// Delete file entry in media library
 		getActivity().getContentResolver().delete(
 				MediaStore.Files.getContentUri("external"),
@@ -96,7 +95,7 @@ public class ExportTrackTaskTest extends ActivityInstrumentationTestCase2<TrackM
 		Assert.assertTrue(trackFile.exists());
 		Assert.assertEquals(
 				readFully(
-						getInstrumentation().getContext().getAssets().open("gpx/gpx-test.gpx")),
+						InstrumentationRegistry.getInstrumentation().getContext().getAssets().open("gpx/gpx-test.gpx")),
 				readFully(new FileInputStream(trackFile)));
 
 		// Ensure the media library has been refreshed


### PR DESCRIPTION
This changes should allow the app to pass all travis tests.
Some deprecated modules and classes were being used in test classes.
For example [this one](https://developer.android.com/reference/android/test/ActivityInstrumentationTestCase2.html#setActivityIntent(android.content.Intent)).

In build gradle file some dependencies were outdated so I replaced them with newer ones.

**Important**: this changes are not definitve because according to the developers android page, since API 24, new tests should be written using the [Android Testing Support Library](https://developer.android.com/tools/testing-support-library/index.html) and I can not assure that the current tests follow 100% this new way of writing tests for Android.